### PR TITLE
Enable updating EnScrypt settings for block 2

### DIFF
--- a/src/cryptutil.cpp
+++ b/src/cryptutil.cpp
@@ -921,6 +921,7 @@ bool CryptUtil::updateBlock2(IdentityBlock *block2, QByteArray unencryptedIuk,
     // the block
     else
     {
+        iterationCount = block2->items[4].value.toInt();
         ok = enScryptIterations(key, rescueCode, randomSalt, logNFactor, iterationCount, progressDialog);
     }
 

--- a/src/cryptutil.h
+++ b/src/cryptutil.h
@@ -61,10 +61,11 @@ public:
     static QByteArray createIlkFromIuk(QByteArray decryptedIuk);
     static QByteArray createIndexedSecret(QByteArray imk, QString domain, QString altId, QByteArray secretIndex);
     static QByteArray enHash(QByteArray data);
-    static IdentityBlock createBlock1(QByteArray iuk, QString password, QProgressDialog* progressDialog);
-    static IdentityBlock createBlock2(QByteArray iuk, QString rescueCode, QProgressDialog* progressDialog);
-    static bool updateBlock1WithPassword(IdentityBlock* oldBlock, IdentityBlock* updatedBlock, QString password, QString newPassword, QProgressDialog* progressDialog);
-    static bool updateBlock1(IdentityBlock* block1, QByteArray unencryptedImk, QByteArray unencryptedIlk, QString newPassword, QProgressDialog* progressDialog);
+    static IdentityBlock createBlock1(QByteArray iuk, QString password, QProgressDialog* progressDialog = nullptr);
+    static IdentityBlock createBlock2(QByteArray iuk, QString rescueCode, QProgressDialog* progressDialog = nullptr);
+    static bool updateBlock1WithPassword(IdentityBlock* oldBlock, IdentityBlock* updatedBlock, QString password, QString newPassword, QProgressDialog* progressDialog = nullptr);
+    static bool updateBlock1(IdentityBlock* block1, QByteArray unencryptedImk, QByteArray unencryptedIlk, QString newPassword, QProgressDialog* progressDialog = nullptr);
+    static bool updateBlock2(IdentityBlock* block2, QByteArray unencryptedIuk, QString rescueCode, int secondsToRunScrypt = -1, QProgressDialog* progressDialog = nullptr);
     static QByteArray aesGcmEncrypt(QByteArray message, QByteArray additionalData, QByteArray iv, QByteArray key);
     static QByteArray createIuk();
     static QString createNewRescueCode();

--- a/src/idsetdialog.cpp
+++ b/src/idsetdialog.cpp
@@ -37,22 +37,23 @@
  * obtaining the block's identity keys (IMK and ILK). Consequently,
  * the keys will be reencrypted using the (changed) settings as "additional
  * data" for the authenticated re-encryption of the identity keys.
+ * 
  *
 */
 
 
 /*!
  * Creates a new \c IdentitySettingsDialog window, using \a parent as the
- * parent form and storing a \a block1 pointer internally for accessing the
- * identity's settings.
+ * parent form and \a identity as the identity who's settings should be changed.
  */
 
-IdentitySettingsDialog::IdentitySettingsDialog(QWidget *parent, IdentityBlock* block1) :
+IdentitySettingsDialog::IdentitySettingsDialog(QWidget *parent, IdentityModel* identity) :
     QDialog(parent),
     ui(new Ui::IdentitySettingsDialog)
 {
     ui->setupUi(this);
-    m_pBlock1 = block1;
+    m_pBlock1 = identity->getBlock(1);
+    m_pBlock2 = identity->getBlock(2);
 
     connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(onSaveButtonClicked()));
     connect(ui->buttonBox->button(QDialogButtonBox::Reset), SIGNAL(clicked()), SLOT(onResetButtonClicked()));

--- a/src/idsetdialog.cpp
+++ b/src/idsetdialog.cpp
@@ -26,6 +26,7 @@
 
 #include "idsetdialog.h"
 #include "ui_idsetdialog.h"
+#include "mainwindow.h"
 
 /*!
  *
@@ -185,12 +186,44 @@ void IdentitySettingsDialog::onSaveButtonClicked()
     if (!ok)
     {
         QMessageBox::critical(this, tr("Error"), tr("Operation failed! Wrong password?"));
+        return;
     }
 
     *m_pBlock1 = newBlock1;
+    
+    // Should block 2 be updated as well?
+    if (!ui->chk_UpdateBlock2->isChecked()) return;
+    
+    IdentityBlock newBlock2(*m_pBlock2);
+    
+    QString rescueCode;
+    ok = MainWindow::showGetRescueCodeDialog(rescueCode, this);
+    if (!ok) return;
+    
+    QByteArray decryptedIuk(32, 0);
+    ok = CryptUtil::decryptBlock2(decryptedIuk, &newBlock2, rescueCode, &progressDialog);
+    if (!ok)
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Error decrypting block 2! Wrong rescue code?"));
+        return;
+    }
+    
+    // Set the same scrypt parameters than on block 1
+    newBlock2.items[3].value = newBlock1.items[5].value;
+    newBlock2.items[4].value = newBlock1.items[6].value;
+    
+    // Update block 2
+    ok = CryptUtil::updateBlock2(&newBlock2, decryptedIuk, rescueCode, -1, &progressDialog);
+    if (!ok)
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Error updating block 2!"));
+        return;
+    }
+    
+    *m_pBlock2 = newBlock2;
 }
 
 void IdentitySettingsDialog::onResetButtonClicked()
 {
-    loadBlockData();
+    loadBlockData();   
 }

--- a/src/idsetdialog.h
+++ b/src/idsetdialog.h
@@ -47,9 +47,10 @@ class IdentitySettingsDialog : public QDialog
 private:
     Ui::IdentitySettingsDialog *ui;
     IdentityBlock* m_pBlock1 = nullptr;
+    IdentityBlock* m_pBlock2 = nullptr;
 
 public:
-    IdentitySettingsDialog(QWidget *parent, IdentityBlock* block1);
+    IdentitySettingsDialog(QWidget *parent, IdentityModel* id);
     ~IdentitySettingsDialog();
 
 private:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -574,11 +574,10 @@ void MainWindow::onResetPassword()
 
 void MainWindow::onShowIdentitySettingsDialog()
 {
-    IdentityBlock* pBlock1 = m_pTabManager->getCurrentTab()
-            .getIdentityModel().getBlock(1);
-    if (pBlock1 == nullptr) return;
+    IdentityModel& currentIdentity = m_pTabManager->getCurrentTab()
+            .getIdentityModel();
 
-    IdentitySettingsDialog dialog(this, pBlock1);
+    IdentitySettingsDialog dialog(this, &currentIdentity);
     if (dialog.exec() == QDialog::Accepted)
     {
         m_pTabManager->getCurrentTab().rebuild();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -56,14 +56,16 @@ private:
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
+    
+public:
+    static bool showGetRescueCodeDialog(QString& rescueCode, QWidget* parent = nullptr);
+    static bool showGetPasswordDialog(QString& password, QWidget* parent = nullptr);
+    static bool showGetNewPasswordDialog(QString& password, QWidget* parent = nullptr);
 
 private:
     void showNoIdentityLoadedError();
     void showTextualIdentityInfoDialog(QString rescueCode = nullptr);
     void configureMenuItems();
-    bool showGetRescueCodeDialog(QString& rescueCode, QWidget* parent = nullptr);
-    bool showGetPasswordDialog(QString& password, QWidget* parent = nullptr);
-    bool showGetNewPasswordDialog(QString& password, QWidget* parent = nullptr);
     bool canDiscardChanges();
 
 private: // Overrides

--- a/ui/idsetdialog.ui
+++ b/ui/idsetdialog.ui
@@ -33,76 +33,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QSpinBox" name="spnQuickPassLength">
-     <property name="maximum">
-      <number>999999</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="spnPasswordVerifySeconds">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>9999</number>
-     </property>
-     <property name="value">
-      <number>1</number>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Reset|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QSpinBox" name="spnQuickPassTimeout">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>9999</number>
-     </property>
-     <property name="value">
-      <number>1</number>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblQuickPassLength">
-     <property name="text">
-      <string>QuickPass length:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblPasswordVerifySeconds">
-     <property name="text">
-      <string>Password verification time (seconds):</string>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="0" colspan="3">
     <widget class="QGroupBox" name="grpOptionFlags">
      <property name="title">
@@ -178,6 +108,19 @@
      </layout>
     </widget>
    </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QSpinBox" name="spnQuickPassTimeout">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>9999</number>
+     </property>
+     <property name="value">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
@@ -193,6 +136,89 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Reset|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="spnPasswordVerifySeconds">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>9999</number>
+     </property>
+     <property name="value">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="lblPasswordVerifySeconds">
+     <property name="text">
+      <string>Password verification time (seconds):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblQuickPassLength">
+     <property name="text">
+      <string>QuickPass length:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QSpinBox" name="spnQuickPassLength">
+     <property name="maximum">
+      <number>999999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <widget class="QCheckBox" name="chk_UpdateBlock2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Use identical scrypt settings for block 2 (requires rescue code)</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This adds an option to the identity settings dialog which ebables applying the _EnScrypt_ parameters which were chosen for block 1 also for block type 2.